### PR TITLE
Reset chosen loot in chaos room to avoid showing previous gods

### DIFF
--- a/game/scripts/loot/LootRoomDuplicated.lua
+++ b/game/scripts/loot/LootRoomDuplicated.lua
@@ -215,9 +215,6 @@ function LootRoomDuplicated.SpawnRoomReward(baseFun, eventSource, args)
     end
 
     for playerId, hero in CoopPlayers.PlayersIterator() do
-		if RunEx.IsSecretRoom(room) then
-			LootRoomDuplicated.ChosenPlayerLoot[playerId] = nil
-		end
         local lootParams = LootRoomDuplicated.ChosenPlayerLoot[playerId] or {}
         if not hero.IsDead then
             room.ChangeReward = lootParams.rewardType
@@ -226,6 +223,7 @@ function LootRoomDuplicated.SpawnRoomReward(baseFun, eventSource, args)
             HeroContext.RunWithHeroContextAwait(hero, baseFun, eventSource, args)
         end
     end
+    LootRoomDuplicated.ChosenPlayerLoot = {}
 end
 
 ---@param heroesCount number

--- a/game/scripts/loot/LootRoomDuplicated.lua
+++ b/game/scripts/loot/LootRoomDuplicated.lua
@@ -215,6 +215,9 @@ function LootRoomDuplicated.SpawnRoomReward(baseFun, eventSource, args)
     end
 
     for playerId, hero in CoopPlayers.PlayersIterator() do
+		if RunEx.IsSecretRoom(room) then
+			LootRoomDuplicated.ChosenPlayerLoot[playerId] = nil
+		end
         local lootParams = LootRoomDuplicated.ChosenPlayerLoot[playerId] or {}
         if not hero.IsDead then
             room.ChangeReward = lootParams.rewardType


### PR DESCRIPTION
When entering Chaos room in "duplicated" mode, the previously chosen gods were shown for both players.

Now both players get Chaos.